### PR TITLE
TagField component stabilisations

### DIFF
--- a/packages/ui/src/core/tag-field/tag-field.component.tsx
+++ b/packages/ui/src/core/tag-field/tag-field.component.tsx
@@ -92,12 +92,19 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
 
     const convertToLower = (value: string): string => value.toLocaleLowerCase();
 
-    const isSuggestedTag = (input: string) =>
-      suggestedTags.some((suggested: any) => convertToLower(getTagLabel(suggested))?.includes(convertToLower(input)));
+    const findSuggestedTagByLabel = (input: string) =>
+      suggestedTags.find((suggested: any) => convertToLower(getTagLabel(suggested)) === convertToLower(input));
 
     const handleAddingTag = (): void => {
-      if (userInput && !isSuggestedTag(userInput)) {
-        handleTagAdd(userInput, AddTagType.UserInput);
+      if (userInput) {
+        const suggestedTag = findSuggestedTagByLabel(userInput);
+
+        if (!suggestedTag) {
+          handleTagAdd(userInput, AddTagType.UserInput);
+        } else if (!tags.some((tag: TagType) => getTagValue(tag) === getTagValue(suggestedTag))) {
+          handleTagAdd(userInput, AddTagType.Suggestion);
+        }
+
         setUserInput('');
       }
     };

--- a/packages/ui/src/core/tag-field/tag-field.component.tsx
+++ b/packages/ui/src/core/tag-field/tag-field.component.tsx
@@ -73,8 +73,8 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
       [filteredTags]
     );
     const filteredSuggestions = useMemo(() => {
-      const filteredItems = suggestedTags.filter(
-        (suggestion) => !existingLabels.includes(getTagLabel(suggestion).toLowerCase())
+      const filteredItems = suggestedTags?.filter(
+        (suggestion) => !existingLabels?.includes(getTagLabel(suggestion)?.toLowerCase())
       );
 
       return suggestionsFilter(filteredItems, userInput, getTagLabel, alwaysShowSuggestedTags);
@@ -82,7 +82,6 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
 
     const handleTagAdd = (item: any, type: AddTagTypesType): void => {
       if (!item) return;
-
       const tagLabel = type === AddTagType.UserInput ? item : getTagLabel(item);
 
       if (!filteredTags.some((tag: TagType) => getTagLabel(tag).toLowerCase() === tagLabel.toLowerCase())) {
@@ -92,21 +91,23 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
 
     const convertToLower = (value: string): string => value.toLocaleLowerCase();
 
-    const findSuggestedTagByLabel = (input: string) =>
-      suggestedTags.find((suggested: any) => convertToLower(getTagLabel(suggested)) === convertToLower(input));
+    const isMatchingSuggestedTag = filteredSuggestions.some(
+      (item) => convertToLower(getTagLabel(item)) === convertToLower(userInput)
+    );
 
     const handleAddingTag = (): void => {
       if (userInput) {
-        const suggestedTag = findSuggestedTagByLabel(userInput);
-
-        if (!suggestedTag) {
+        if (isMatchingSuggestedTag) {
+          const nextUserInput = filteredSuggestions.find(
+            (item) => convertToLower(getTagLabel(item)) === convertToLower(userInput)
+          );
+          handleTagAdd(nextUserInput, AddTagType.Suggestion);
+        } else {
           handleTagAdd(userInput, AddTagType.UserInput);
-        } else if (!filteredTags.some((tag: TagType) => getTagValue(tag) === getTagValue(suggestedTag))) {
-          handleTagAdd(userInput, AddTagType.Suggestion);
         }
-
-        setUserInput('');
       }
+
+      setUserInput('');
     };
 
     const handleTagsValidation = (): void => {
@@ -124,8 +125,6 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
         setTagsHint('');
         setTagsError(false);
         handleAddingTag();
-      } else {
-        handleAddingTag();
       }
     };
 
@@ -139,7 +138,7 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
     const handleUserInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
       if ((event.key === 'Enter' && !disableOnEnter) || (event.key === ' ' && submitOnSpace)) {
         event.preventDefault();
-        handleTagsValidation();
+        handleAddingTag();
       } else if (event.key === 'Backspace' && !userInput && filteredTags?.length > 0) {
         const index = filteredTags.length - 1;
         onRemove(index, getTagValue(filteredTags[index]), setUserInput, event);
@@ -278,6 +277,7 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
                   type="suggested"
                   crossIcon={false}
                   onSelect={() => {
+                    console.log('ssssssssss');
                     handleTagAdd(suggestion, AddTagType.Suggestion);
                     setUserInput('');
                   }}

--- a/packages/ui/src/core/tag-field/tag-field.component.tsx
+++ b/packages/ui/src/core/tag-field/tag-field.component.tsx
@@ -101,7 +101,7 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
 
         if (!suggestedTag) {
           handleTagAdd(userInput, AddTagType.UserInput);
-        } else if (!tags.some((tag: TagType) => getTagValue(tag) === getTagValue(suggestedTag))) {
+        } else if (!filteredTags.some((tag: TagType) => getTagValue(tag) === getTagValue(suggestedTag))) {
           handleTagAdd(userInput, AddTagType.Suggestion);
         }
 
@@ -140,7 +140,7 @@ const TagField = intrinsicComponent<TagFieldProps, HTMLDivElement>(
       if ((event.key === 'Enter' && !disableOnEnter) || (event.key === ' ' && submitOnSpace)) {
         event.preventDefault();
         handleTagsValidation();
-      } else if (event.key === 'Backspace' && !userInput) {
+      } else if (event.key === 'Backspace' && !userInput && filteredTags?.length > 0) {
         const index = filteredTags.length - 1;
         onRemove(index, getTagValue(filteredTags[index]), setUserInput, event);
       }

--- a/packages/ui/src/core/tag-field/tag-field.utils.ts
+++ b/packages/ui/src/core/tag-field/tag-field.utils.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from '@scaleflex/ui/utils/functions';
 import type { TagType, SuggestionsFilterFnType } from './tag-field.props';
 
 const tagsSuggestionsFilter = <SuggestionsFilterFnType>((
@@ -17,7 +18,7 @@ const tagsSuggestionsFilter = <SuggestionsFilterFnType>((
   let suggestions = [...suggestedTags];
 
   if (userInput) {
-    const regexp = new RegExp(userInput, 'i');
+    const regexp = new RegExp(escapeRegExp(userInput), 'i');
 
     suggestions = suggestions.filter((suggestion: TagType) => regexp.test(getTagLabel(suggestion)));
   }

--- a/packages/ui/src/utils/functions/escape-regexp.ts
+++ b/packages/ui/src/utils/functions/escape-regexp.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(text: string): string {
+  return text.replace(/[\s#$()*+,.?[\\\]^{|}-]/g, '\\$&');
+}

--- a/packages/ui/src/utils/functions/index.ts
+++ b/packages/ui/src/utils/functions/index.ts
@@ -11,3 +11,4 @@ export * from './color-picker/color-converters';
 export * from './get-elem-document-coords';
 export * from './slider/utils';
 export * from './scrollbar';
+export * from './escape-regexp';


### PR DESCRIPTION
Fixes for TagField component errors:
- Typing  symbol “\” cause JS error: `Uncaught SyntaxError: Invalid regular expression: /\/i: \ at end of pattern`
- (Objects suggestions case) When we type some actual suggestion label and press enter nothing happen (when some suggestions are visible). It should select suggestion if we have exact match or run addTag handler with user-input type.
- Press Backspace in empty field cause error: `Uncaught TypeError: Cannot read properties of undefined (reading 'id')`