### PR TITLE
chore: Add data-icon-name for all icons (to support automation testing)

### DIFF
--- a/packages/icons/.babelrc.js
+++ b/packages/icons/.babelrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require('../../scripts/babel')({ styledComponents: false }),
+  ...require('../../scripts/babel')({ styledComponents: false, jsxAddIconName: true }),
 };

--- a/scripts/babel-plugin-transform-react-jsx-add-icon-name.js
+++ b/scripts/babel-plugin-transform-react-jsx-add-icon-name.js
@@ -1,0 +1,61 @@
+/**
+ * This adds data-icon-name to <svg > tags (as first props)
+ *
+ * == JSX Literals ==
+ * <svg {props...}>...</svg>
+ *
+ * becomes:
+ * <svg data-icon-name="ComponentVariableName" {props...}>...</svg>
+ */
+
+const { declare } = require('@babel/helper-plugin-utils');
+const { types: t } = require('@babel/core');
+
+const ICON_NAME_ATTRIBUTE = 'data-icon-name';
+
+module.exports = declare((api) => {
+  const isIconNameAttr = (attr) => t.isJSXAttribute(attr) && attr.name.name === ICON_NAME_ATTRIBUTE;
+
+  const getIconName = (path) => {
+    let parentPath = path.parentPath;
+    while (parentPath) {
+      if (parentPath?.node.type === 'VariableDeclarator' && !!parentPath?.node?.id?.name) {
+        return parentPath?.node?.id?.name;
+      }
+      parentPath = parentPath.parentPath;
+    }
+    return null;
+  };
+
+  return {
+    name: 'transform-react-jsx-add-icon-name',
+    visitor: {
+      JSXOpeningElement(path, state) {
+        const { node } = path;
+        if (
+          // Make sure only process necessary files
+          !state.filename ||
+          !state.filename.match(/packages[/\\]icons[/\\]src[/\\][^/\\]+\.tsx$/) ||
+          !state.file?.code ||
+          !state.file.code.includes('intrinsicComponent') ||
+          !state.file.code.includes('IconProps') ||
+          // Only process svg as first node of JSXElement (don't process deep <svg>)
+          path.parentPath?.node?.type !== 'JSXElement' ||
+          // Only process svg tags
+          node.name.name !== 'svg' ||
+          // the element was generated and doesn't have location information
+          !node.loc ||
+          // Already has data-svg-name
+          path.node.attributes.some(isIconNameAttr)
+        ) {
+          return;
+        }
+        const iconName = getIconName(path);
+        if (iconName) {
+          // To prevent overriding existed data-svg-name in source code, add attribute as first item of array
+          node.attributes.unshift(t.jsxAttribute(t.jsxIdentifier(ICON_NAME_ATTRIBUTE), t.stringLiteral(`${iconName}`)));
+        }
+      },
+    },
+  };
+});

--- a/scripts/babel.js
+++ b/scripts/babel.js
@@ -1,3 +1,5 @@
+const babelPluginJsxAddIconName = require('./babel-plugin-transform-react-jsx-add-icon-name');
+
 const presets = {
   env: ['@babel/preset-env', { modules: false }],
   react: '@babel/preset-react',
@@ -6,7 +8,7 @@ const presets = {
 const plugins = {
   styledComponents: ['styled-components', { displayName: false, fileName: false, pure: true }],
   runtime: '@babel/plugin-transform-runtime',
-  classProperties: 'transform-class-properties'
+  classProperties: 'transform-class-properties',
 };
 
 const withConfig = (shouldUse, config) => (shouldUse ? [config] : []);
@@ -18,15 +20,16 @@ const applyConfigs = (object, options) => {
 };
 
 module.exports = (options = {}) => {
-  const { styledComponents = true, react = true, env = true, runtime, classProperties } = options;
-
+  const { styledComponents = true, react = true, env = true, runtime, classProperties, jsxAddIconName } = options;
   return {
     presets: [...applyConfigs(presets, { react, env }), '@babel/preset-typescript'],
-    plugins: [...applyConfigs(plugins, { styledComponents, runtime, classProperties }),
+    plugins: [
+      ...applyConfigs(plugins, { styledComponents, runtime, classProperties }),
       ['@babel/plugin-proposal-private-methods', { loose: true }],
       ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
-      ["@babel/plugin-transform-class-properties", { "loose": true }]
+      ['@babel/plugin-transform-class-properties', { loose: true }],
+      ...(jsxAddIconName ? [[babelPluginJsxAddIconName]] : []),
     ],
     ignore: ['src/**/*.d.ts'],
-  };  
+  };
 };


### PR DESCRIPTION
Context: 
Automation testing team need a way to select (using css selector) then click some button with only icon inside.

What I'm doing:
=> I'm trying to propose an automatic way to add data-icon-name to all icon component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced icon rendering: Icon components now include additional metadata for improved appearance consistency and easier troubleshooting.
	- Introduced an optional configuration setting to enable the new icon enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->